### PR TITLE
[Reviewer: Mat] Alter timeout ordering with connections

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1300,6 +1300,54 @@ static CURLcode multi_do_more(struct connectdata *conn, int *complete)
   return result;
 }
 
+static bool multi_handle_timeout(struct Curl_easy *data,
+                                 struct curltime *now,
+                                 bool *stream_error,
+                                 CURLcode *result,
+                                 bool connect_timeout)
+{
+  time_t timeout_ms;
+  timeout_ms = Curl_timeleft(data, now, connect_timeout);
+
+  if(timeout_ms < 0) {
+
+    /* Handle timed out */
+    if(data->mstate == CURLM_STATE_WAITRESOLVE)
+      failf(data, "Resolving timed out after %ld milliseconds",
+            Curl_tvdiff(*now, data->progress.t_startsingle));
+    else if(data->mstate == CURLM_STATE_WAITCONNECT)
+      failf(data, "Connection timed out after %ld milliseconds",
+            Curl_tvdiff(*now, data->progress.t_startsingle));
+    else {
+      struct SingleRequest *k = &data->req;
+      if(k->size != -1) {
+        failf(data, "Operation timed out after %ld milliseconds with %"
+              CURL_FORMAT_CURL_OFF_T " out of %"
+              CURL_FORMAT_CURL_OFF_T " bytes received",
+              Curl_tvdiff(*now, data->progress.t_startsingle),
+              k->bytecount, k->size);
+      }
+      else {
+        failf(data, "Operation timed out after %ld milliseconds with %"
+              CURL_FORMAT_CURL_OFF_T " bytes received",
+              Curl_tvdiff(*now, data->progress.t_startsingle),
+              k->bytecount);
+      }
+    }
+
+    /* Force connection closed if the connection has indeed been used */
+    if(data->mstate > CURLM_STATE_DO) {
+      streamclose(data->easy_conn, "Disconnected with pending data");
+      *stream_error = TRUE;
+    }
+
+    *result = CURLE_OPERATION_TIMEDOUT;
+    (void)multi_done(&data->easy_conn, *result, TRUE);
+  }
+
+  return (timeout_ms < 0);
+}
+
 static CURLMcode multi_runsingle(struct Curl_multi *multi,
                                  struct curltime now,
                                  struct Curl_easy *data)
@@ -1313,7 +1361,6 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
   CURLMcode rc;
   CURLcode result = CURLE_OK;
   struct SingleRequest *k;
-  time_t timeout_ms;
   time_t recv_timeout_ms;
   time_t send_timeout_ms;
   int control;
@@ -1368,45 +1415,14 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
     if(data->easy_conn &&
        (data->mstate >= CURLM_STATE_CONNECT) &&
        (data->mstate < CURLM_STATE_COMPLETED)) {
+      /* We defer handling the connection timeout to later, to see if the
+       * connection has actually succeeded. */
+
       /* we need to wait for the connect state as only then is the start time
          stored, but we must not check already completed handles */
+      if (multi_handle_timeout(data, &now, &stream_error, &result, FALSE))
+      {
 
-      timeout_ms = Curl_timeleft(data, &now,
-                                 (data->mstate <= CURLM_STATE_WAITDO)?
-                                 TRUE:FALSE);
-
-      if(timeout_ms < 0) {
-        /* Handle timed out */
-        if(data->mstate == CURLM_STATE_WAITRESOLVE)
-          failf(data, "Resolving timed out after %ld milliseconds",
-                Curl_tvdiff(now, data->progress.t_startsingle));
-        else if(data->mstate == CURLM_STATE_WAITCONNECT)
-          failf(data, "Connection timed out after %ld milliseconds",
-                Curl_tvdiff(now, data->progress.t_startsingle));
-        else {
-          k = &data->req;
-          if(k->size != -1) {
-            failf(data, "Operation timed out after %ld milliseconds with %"
-                  CURL_FORMAT_CURL_OFF_T " out of %"
-                  CURL_FORMAT_CURL_OFF_T " bytes received",
-                  Curl_tvdiff(now, data->progress.t_startsingle),
-                  k->bytecount, k->size);
-          }
-          else {
-            failf(data, "Operation timed out after %ld milliseconds with %"
-                  CURL_FORMAT_CURL_OFF_T " bytes received",
-                  Curl_tvdiff(now, data->progress.t_startsingle),
-                  k->bytecount);
-          }
-        }
-
-        /* Force connection closed if the connection has indeed been used */
-        if(data->mstate > CURLM_STATE_DO) {
-          streamclose(data->easy_conn, "Disconnected with pending data");
-          stream_error = TRUE;
-        }
-        result = CURLE_OPERATION_TIMEDOUT;
-        (void)multi_done(&data->easy_conn, result, TRUE);
         /* Skip the statemachine and go directly to error handling section. */
         goto statemachine_end;
       }
@@ -2063,6 +2079,18 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
     default:
       return CURLM_INTERNAL_ERROR;
     }
+
+    if (data->easy_conn &&
+        data->mstate >= CURLM_STATE_CONNECT &&
+        data->mstate <= CURLM_STATE_WAITDO &&
+        rc != CURLM_CALL_MULTI_PERFORM &&
+        multi_ischanged(multi, false))
+    {
+      /* We now handle stream timeouts if and only if this will be the last loop
+       * iteration */
+      multi_handle_timeout(data, &now, &stream_error, &result, TRUE);
+    }
+
     statemachine_end:
 
     if(data->mstate < CURLM_STATE_COMPLETED) {

--- a/lib/url.c
+++ b/lib/url.c
@@ -6238,9 +6238,12 @@ static CURLcode resolve_server(struct Curl_easy *data,
       if(rc == CURLRESOLV_PENDING)
         *async = TRUE;
 
-      else if(rc == CURLRESOLV_TIMEDOUT)
+      else if(rc == CURLRESOLV_TIMEDOUT) {
+        failf(data, "Failed to resolve host '%s' with timeout after %ld ms",
+              connhost->dispname,
+              Curl_tvdiff(now, data->progress.t_startsingle));
         result = CURLE_OPERATION_TIMEDOUT;
-
+      }
       else if(!hostaddr) {
         failf(data, "Couldn't resolve host '%s'", connhost->dispname);
         result =  CURLE_COULDNT_RESOLVE_HOST;


### PR DESCRIPTION
Matt,

We've been seeing a number of HTTP errors during high load which, from packet capture analysis, don't represent genuine transport failure.

The following is causing an erroneous failure to be detected:

- Request that curl connects to a server with a very short connection timeout (~50ms) and a much longer request timeout (~1s). This is done in order to quickly detect failed nodes within the same site.

- Curl connects to the site, and blocks (using select on the file descriptor for that to complete).

- The kernel removes the task from the run queue, and moves on to other work

- The connection completes ~100 microseconds later and the kernel marks the task as runnable.

- However, the system is under load, and thus the task doesn't get executed immediately. In some scenarios, it may take up to 100ms for the task to be scheduled.

- The task is then run, Curl compares the timer, spots the timeout, and returns an error saying the task has timed out, despite also having in it's hand the connected connection.

Increasing the connection timeout here is undesirable, mainly because it'll take us longer to spot connection death.

This pull request is designed to mitigate the worst of this by:

- Check whether a connection has succeded before checking whether it's timed
  out.

  This means if we've connected quickly, but subsequently been descheduled, we
  allow the connection to succeed. Note, if we timeout, but between checking the
  timeout, and connecting to the server the connection succeeds, we will allow
  it to go ahead. This is viewed as an acceptable trade off.

- Add additional failf logging around failed connection attempts to propagate
  the cause up to the caller.

I've done a substantially amount of testing with this fix, and this mitigates most of the problems we've seen, and appears to be reliable in practice.